### PR TITLE
correcting typescript typing for an array tuple

### DIFF
--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -21,7 +21,7 @@ export interface UsePopperProps {
    * The main and cross-axis offset to displace popper element
    * from its reference element.
    */
-  offset?: [crossAxis: number, mainAxis: number]
+  offset?: [number, number]
   /**
    * The distance or margin between the reference and popper.
    * It is used internally to create an `offset` modifier.


### PR DESCRIPTION
usePopper.offset had an incorrectly defined type
`offset?: [crossAxis: number, mainAxis: number]` is not valid typescript and throws an error on a `tsc -p . --noEmit`

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

bugfix - typescript error on tuple definition for use-popper.ts

## ⛳️ Current behavior (updates)

current UsePopperProps interface defines a tuple, but tries to assign (incorrectly) property names to the tuple positions.

## 🚀 New behavior

Corrects tuple definition by removing the property names.

## 💣 Is this a breaking change (Yes/No):

No, in fact this fixes type checking if you're pulling in types from the chakra package.

## 📝 Additional Information
