### PR TITLE
Update use-popper.ts

### DIFF
--- a/packages/popper/src/use-popper.ts
+++ b/packages/popper/src/use-popper.ts
@@ -20,8 +20,9 @@ export interface UsePopperProps {
   /**
    * The main and cross-axis offset to displace popper element
    * from its reference element.
+   * usage/positions: [crossAxis: number, mainAxis: number]
    */
-  offset?: [crossAxis: number, mainAxis: number]
+  offset?: [number, number]
   /**
    * The distance or margin between the reference and popper.
    * It is used internally to create an `offset` modifier.


### PR DESCRIPTION
Fixes tuple definition on use-popper

<!---
Thanks for creating an Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Tuple definition on use-popper is incorrect - it attempts to define parameter names in the type definition in addition to the type. This fundamentally breaks the typing. Updated typing and documentation to address this issue.

## ⛳️ Current behavior (updates)

Typing tuple for offset is incorrect and doesn't pass tsc -p . --noEmit` type checking.

## 🚀 New behavior

Corrects the tuple type and provides some inline documentation on the definition.

## 💣 Is this a breaking change (Yes/No):

No impact for existing chakra users - this will allow it to work correctly as well as users to use the types directly. 


## 📝 Additional Information

Might recommend moving to an object in order to define the parameters, eg. (offset?: { crossAxis: number, mainAxis: number } instead of a tuple. However leaving it as a tuple currently does not cause a breaking change, which is preferable).